### PR TITLE
Unify manpage format

### DIFF
--- a/manpages/java_remove_annotations.7.adoc
+++ b/manpages/java_remove_annotations.7.adoc
@@ -1,7 +1,7 @@
 = java_remove_annotations(7)
-:doctype:       manpage
-:man source:    JURAND
-:man manual:    Jurand
+:doctype: manpage
+:mansource: JAVA_REMOVE_ANNOTATIONS
+:manmanual: Java packaging support
 
 == NAME
 java_remove_annotations - remove imports and annotations from Java source files
@@ -10,7 +10,8 @@ java_remove_annotations - remove imports and annotations from Java source files
 *%java_remove_annotations* [optional flags] <matcher>... [file path]...
 
 == DESCRIPTION
-This macro removes import statements as well as usage of annotations from Java source files. The does the same as *java_remove_imports* and on top of that finds all uses of annotations and matches the content between the '@' symbol and either ending with whitespace or with an opening parethesis '(' (the annotation arguments).
+This macro removes import statements as well as usage of annotations from Java source files.
+This does the same as *java_remove_imports* and on top of that finds all uses of annotations and matches the content between the '@' symbol and either ending with whitespace or with an opening parethesis '(' (the annotation arguments).
 
 In case of match, the script also removes the block of paretheses that follows the matched annotation, if it is present.
 
@@ -25,10 +26,14 @@ Arguments can be specified in arbitrary order.
 Matcher is one of:
 
 *-n <name>*::
-Simple class name to be matched against the simple names of imported symbols. Names are matched for exact equality. Can be specified multiple times.
+Simple class name to be matched against the simple names of imported symbols.
+Names are matched for exact equality.
+Can be specified multiple times.
 
 *-p <pattern>*::
-Regex patterns to be matched against imported symbols. Each imported symbol found in the code is matched against each pattern. Can be specified multiple times.
+Regex patterns to be matched against imported symbols.
+Each imported symbol found in the code is matched against each pattern.
+Can be specified multiple times.
 
 Optional flags:
 

--- a/manpages/java_remove_imports.7.adoc
+++ b/manpages/java_remove_imports.7.adoc
@@ -1,7 +1,7 @@
 = java_remove_imports(7)
-:doctype:       manpage
-:man source:    JURAND
-:man manual:    Jurand
+:doctype: manpage
+:mansource: JAVA_REMOVE_IMPORTS
+:manmanual: Java packaging support
 
 == NAME
 java_remove_imports - remove import statements from Java source files
@@ -10,7 +10,8 @@ java_remove_imports - remove import statements from Java source files
 *%java_remove_imports* [optional flags] <matcher>... [file path]...
 
 == DESCRIPTION
-This macro removes import statements from Java source files. The script matches all non-whitespace content following the 'import [static]' statement against all patterns provided via the *-p* flag and all simple class names against names provided by the *-n* flag.
+This macro removes import statements from Java source files.
+The script matches all non-whitespace content following the 'import [static]' statement against all patterns provided via the *-p* flag and all simple class names against names provided by the *-n* flag.
 
 File path arguments are handled the following way:
 
@@ -23,10 +24,14 @@ Arguments can be specified in arbitrary order.
 Matcher is one of:
 
 *-n <name>*::
-Simple class name to be matched against the simple names of imported symbols. Names are matched for exact equality. Can be specified multiple times.
+Simple class name to be matched against the simple names of imported symbols.
+Names are matched for exact equality.
+Can be specified multiple times.
 
 *-p <pattern>*::
-Regex patterns to be matched against imported symbols. Each imported symbol found in the code is matched against each pattern. Can be specified multiple times.
+Regex patterns to be matched against imported symbols.
+Each imported symbol found in the code is matched against each pattern.
+Can be specified multiple times.
 
 Optional flags:
 

--- a/manpages/jurand.1.adoc
+++ b/manpages/jurand.1.adoc
@@ -1,54 +1,45 @@
-jurand(1)
-=========
+= jurand(1)
 :doctype: manpage
-:manmanual: Jurand Manual
 :mansource: JURAND
+:manmanual: Jurand Manual
 
-NAME
-----
-jurand - Java removal of annotations.
+== NAME
+jurand - Java removal of annotations
 
-SYNOPSIS
---------
-*jurand* [*-n*=_<name>_] [*-p*=_<pattern>_] [*-a*] [*-i*] [*-s*] [_<paths>_...]
+== SYNOPSIS
+*jurand* [*-a*] [*-i*] [*-s*] [*-n*=_<name>_] [*-p*=<pattern>] [_<paths>_...]
 
-DESCRIPTION
------------
+== DESCRIPTION
 A tool for manipulating symbols present in `.java` source files.
 
-The tool can be used for patching `.java` sources in cases where using
-sed is insufficient due to Java language syntax. The tool follows Java
-language rules rather than applying simple regular expressions on the
-source code.
+The tool can be used for patching `.java` sources in cases where using sed is insufficient due to Java language syntax.
+The tool follows Java language rules rather than applying simple regular expressions on the source code.
 
-Currently the tool is able to remove `import` statements and
-annotations.
+Currently the tool is able to remove `import` statements and annotations.
 
-OPTIONS
--------
+== OPTIONS
 *-n*, *--name*=_<name>_::
-  Simple (not fully-qualified) class name.
+Simple (not fully-qualified) class name.
 
 *-p*, *--pattern*=_<pattern>_::
-  Regex pattern to match names used in code.
+Regex pattern to match names used in code.
 
 *-a*::
-  Also remove annotations used in code.
+Also remove annotations used in code.
 
 *-i*, *--in-place*::
-  Replace the contents of files.
+Replace the contents of files.
 
 *-s*, *--strict*::
-  Fail if any of the specified options was redundant and no changes
-  associated with the option were made. This option is only applicable
-  together with *-i*.
+Fail if any of the specified options was redundant and no changes associated with the option were made.
+This option is only applicable together with *-i*.
 
-REPORTING BUGS
---------------
-Bugs should be reported through the Jurand issue tracker at Github:
-https://github.com/fedora-java/jurand/issues.
+== REPORTING BUGS
+Bugs should be reported through the Jurand issue tracker at Github: https://github.com/fedora-java/jurand/issues.
 
-SEE ALSO
---------
+== AUTHOR
+Written by Marián Konček.
+
+== SEE ALSO
 *java_remove_annotations*(7),
 *java_remove_imports*(7).

--- a/src/jurand.cpp
+++ b/src/jurand.cpp
@@ -1,8 +1,6 @@
 #include <array>
-#include <mutex>
 #include <thread>
 #include <utility>
-#include <functional>
 #include <atomic>
 
 #include <java_symbols.hpp>


### PR DESCRIPTION
There are still some small differences in the `SYNOPSIS` section.
But the manpage for a command does not necessarily have to look the same as a manpage for macros.