### PR TITLE
Remove redundant std::move on const reference

### DIFF
--- a/src/jurand.cpp
+++ b/src/jurand.cpp
@@ -139,7 +139,7 @@ Usage: jurand [optional flags] <matcher>... [file path]...
 				
 				try
 				{
-					handle_file(std::move(files[index]), parameters);
+					handle_file(files[index], parameters);
 				}
 				catch (std::exception& ex)
 				{


### PR DESCRIPTION
Eliminate unnecessary use of std::move when passing a value to a function that accepts a const reference. std::move has no effect in this context and may mislead readers about the intent.