### PR TITLE
Annotate return values with nodiscard

### DIFF
--- a/src/java_symbols.hpp
+++ b/src/java_symbols.hpp
@@ -70,7 +70,7 @@ struct Path_origin_entry : std::filesystem::path
 	{
 	}
 	
-	std::string_view origin() const noexcept
+	[[nodiscard]] std::string_view origin() const noexcept
 	{
 		return origin_;
 	}
@@ -102,7 +102,7 @@ struct Mutex
 		return Locked(value_, mutex_);
 	}
 	
-	Locked<const Type, std::mutex> lock() const
+	[[nodiscard]] Locked<const Type, std::mutex> lock() const
 	{
 		return Locked(value_, mutex_);
 	}


### PR DESCRIPTION
Add nodiscard to functions returning values that should not be ignored, such as accessors and lock wrappers.  This helps prevent subtle bugs by alerting developers when important return values are discarded.