### PR TITLE
Avoid narrowing conversion by using operator<< for string output

### DIFF
--- a/src/java_symbols.hpp
+++ b/src/java_symbols.hpp
@@ -637,7 +637,7 @@ try
 			osyncstream << path.native() << ":\n";
 		}
 		
-		osyncstream.write(content.c_str(), content.size());
+		osyncstream << content;
 	}
 	else if (content.size() < original_content.size())
 	{
@@ -649,7 +649,7 @@ try
 		}
 		
 		ofs.exceptions(std::ios_base::badbit | std::ios_base::failbit);
-		ofs.write(content.c_str(), content.size());
+		ofs << content;
 		std::osyncstream(std::clog) << "Removing symbols from file " << path.native() << "\n";
 		
 		if (strict_mode)


### PR DESCRIPTION
Replace calls to write() with operator<< when writing std::string to streams.

std::string::size() returns an unsigned value (size_t), while std::ostream::write() expects a signed std::streamsize, which introduces a narrowing conversion.  Using operator<< is simpler, idiomatic, and avoids this type mismatch.  It also improves readability without changing behavior.