### PR TITLE
Add minimal CMakeLists.txt for IDE integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Note: This is not the primary build system for the project.
+# The authoritative build and test configuration is defined in the Makefile.
+# This CMake file exists solely to support IDE integration and assist
+# contributors in importing the project into development environments.
+
+cmake_minimum_required(VERSION 3.14)
+project(jurand CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_compile_options(-Wall -Wextra -Wpedantic)
+
+add_executable(jurand src/jurand.cpp)
+
+enable_testing()
+add_executable(jurand_test src/jurand_test.cpp)
+add_test(NAME jurand_test COMMAND jurand_test)


### PR DESCRIPTION
Introduce a basic CMake configuration to help developers and contributors import the project into IDEs and development tools that rely on CMake for code navigation and build setup.

This CMake file is not intended as the primary method for building or testing the project; the official build remains defined by the Makefile.  It serves only to improve development workflow and tooling support.